### PR TITLE
Prevent .genesis-skip-link taking up space

### DIFF
--- a/style.css
+++ b/style.css
@@ -932,6 +932,10 @@ img.alignright,
 
 /* # Skip Links
 ---------------------------------------------------------------------------------------------------- */
+.genesis-skip-link {
+	margin: 0;
+}
+
 .genesis-skip-link li {
 	height: 0;
 	width: 0;


### PR DESCRIPTION
Props @craigsimps, see https://github.com/RRWD/genesis-accessible/commit/0bad76362c9ea0fd0b88ef9a95721bc082be819b