### PR TITLE
Add tooling, composer, and phpcs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+# WordPress Coding Standards
+# http://make.wordpress.org/core/handbook/coding-standards/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+.editorconfig export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+composer.json export-ignore
+phpcs.xml.dist export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,30 @@
+# Normalize text file line endings to LF on checkin
+# and prevent conversion to CRLF on checkout.
+* text=auto eol=lf
+
+# Text files.
+*.css text
+*.dist text
+*.js text
+*.json text
+*.md text
+*.php text
+*.po text
+*.pot text
+*.xml text
+
+# Binary files.
+*.eot binary
+*.gif binary
+*.ico binary
+*.jpg binary
+*.mo binary
+*.png binary
+*.ttf binary
+*.woff binary
+*.woff2 binary
+
+# Omit during export.
 .editorconfig export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/composer.lock
+/vendor/

--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ Github project link: https://github.com/copyblogger/genesis-sample/
 3. Activate the Genesis Sample theme.
 4. Inside your WordPress dashboard, go to Genesis > Theme Settings and configure them to your liking.
 
+## For Developers
+
+The version of [Genesis Sample on GitHub](https://github.com/copyblogger/genesis-sample/) includes tooling to check code against WordPress standards. To use it:
+
+1. Install Composer globally on your development machine. [See Composer setup steps](https://getcomposer.org/doc/00-intro.md#downloading-the-composer-executable).
+2. In the command line, change directory to the Genesis Sample folder.
+3. Type the command `composer install` to install PHP development dependencies.
+4. Type `composer phpcs` to run coding standards checks.
+
+You'll see output highlighting issues with PHP files that do not conform to Genesis Sample coding standards.
 
 ## Theme Support
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ The version of [Genesis Sample on GitHub](https://github.com/copyblogger/genesis
 
 You'll see output highlighting issues with PHP files that do not conform to Genesis Sample coding standards.
 
+### Packaging for distribution
+
+1. Switch to the branch you plan to distribute.
+2. Run `composer export` to zip all non-development files as `genesis-sample.zip`.
+
+The `export` command is an alias for `git archive -o genesis-sample.zip HEAD`.
+
 ## Theme Support
 
 Please visit https://my.studiopress.com/help/ for theme support.

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {},
     "scripts": {
-        "phpcs": "phpcs"
+        "phpcs": "phpcs",
+        "export": "git archive -o genesis-sample.zip HEAD"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,22 @@
+{
+    "name": "copyblogger/genesis-sample",
+    "description": "Genesis Sample child theme for the Genesis Framework",
+    "require-dev": {
+        "squizlabs/php_codesniffer": "^3.2",
+        "wp-coding-standards/wpcs": "^0.14.1",
+        "wimg/php-compatibility": "^8.1",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+        "php": "^5.6|^7"
+    },
+    "license": "GPL-2.0+",
+    "authors": [
+        {
+            "name": "StudioPress",
+            "email": "support@studiopress.com"
+        }
+    ],
+    "require": {},
+    "scripts": {
+        "phpcs": "phpcs"
+    }
+}

--- a/lib/woocommerce/woocommerce-setup.php
+++ b/lib/woocommerce/woocommerce-setup.php
@@ -115,7 +115,7 @@ function genesis_sample_woocommerce_image_dimensions_after_theme_setup() {
 	global $pagenow;
 
 	// Checks conditionally to see if we're activating the current theme and that WooCommerce is installed.
-	if ( ! isset( $_GET['activated'] ) || 'themes.php' !== $pagenow || ! class_exists( 'WooCommerce' ) ) {
+	if ( ! isset( $_GET['activated'] ) || 'themes.php' !== $pagenow || ! class_exists( 'WooCommerce' ) ) { // phpcs:ignore WordPress.CSRF.NonceVerification.NoNonceVerification -- low risk, follows official snippet at https://goo.gl/nnHHQa.
 		return;
 	}
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,64 @@
+<?xml version="1.0"?>
+<ruleset name="Genesis Sample Code Standards">
+	<!-- See https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
+	<!-- See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->
+	<!-- See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki -->
+	<!-- See https://github.com/wimg/PHPCompatibility -->
+	<!-- See https://github.com/Automattic/_s/blob/master/phpcs.xml.dist -->
+
+	<description>Custom rules for Genesis Sample.</description>
+
+	<!-- Check files in this directory and subdirectories. -->
+	<file>.</file>
+
+	<!-- Prevent sniffs of some directories. -->
+	<exclude-pattern>/vendor/</exclude-pattern>
+
+	<!-- Pass flags to PHPCS:
+		 p: Show progress of the run.
+		 s: Show sniff codes in all reports.
+		 v: Print verbose output.
+	-->
+	<arg value="psv"/>
+
+	<!-- Only check PHP and CSS files. -->
+	<arg name="extensions" value="php,css"/>
+
+	<!-- Use the WordPress ruleset, with exclusions. -->
+	<rule ref="WordPress">
+		<exclude name="WordPress.VIP"/>
+		<exclude name="Squiz.PHP.CommentedOutCode.Found"/>
+	</rule>
+
+	<!-- Test PHP cross-version compatibility. -->
+	<config name="testVersion" value="5.2-"/>
+	<rule ref="PHPCompatibility"/>
+
+	<!-- Check for correct text domain on all translatable strings. -->
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array" value="genesis-sample"/>
+		</properties>
+	</rule>
+
+	<!-- Verify that no WP functions are used which are deprecated or removed. -->
+	<rule ref="WordPress.WP.DeprecatedFunctions">
+		<properties>
+			<property name="minimum_supported_version" value="4.4"/>
+		</properties>
+	</rule>
+
+	<!-- Check all globals have the expected prefix. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<property name="prefixes" type="array" value="genesis_sample,CHILD_THEME"/>
+		</properties>
+	</rule>
+
+	<!-- Allow theme-specific exceptions to WordPress filename rules. -->
+	<rule ref="WordPress.Files.FileName">
+		<properties>
+			<property name="is_theme" value="true"/>
+		</properties>
+	</rule>
+</ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -30,6 +30,11 @@
 		<exclude name="Squiz.PHP.CommentedOutCode.Found"/>
 	</rule>
 
+	<!-- Page templates currently use underscores for historic reasons. -->
+	<rule ref="WordPress.Files.FileName.NotHyphenatedLowercase">
+		<exclude-pattern>page_landing.php</exclude-pattern>
+	</rule>
+
 	<!-- Test PHP cross-version compatibility. -->
 	<config name="testVersion" value="5.2-"/>
 	<rule ref="PHPCompatibility"/>


### PR DESCRIPTION
This pull request makes these changes to the beta branch:

- Adds an editor config file (attempts to automate basic code style in supported editors).
- Adds `.gitignore` to prevent `composer.lock` and composer's `/vendor/` directory being committed.
- Adds an [ignore comment](https://github.com/copyblogger/genesis-sample/pull/79/commits/3b2c7239809f71ae6d24cc488ae53600fc192f39) for the final phpcs warning mentioned in https://github.com/copyblogger/genesis-sample/issues/76.
- Adds a phpcs config file (establishes which standards checks we want to use and ignore).
- Adds the `composer phpcs` command to run standards checks.
- Adds the `composer export` command to export a zip of the current branch via `git archive`.
- Documents how to install composer, use phpcs, and export all files to a zip excluding config files.

Before we release future versions, we can now:

- Run `composer phpcs` to check for standards issues.
- Run `composer export` from the release branch to create the zip file for upload to my.studiopress.com. This version will not include developer config files, but the readme now notes that they're available in GitHub.

Thanks to @dreamwhisper, @GaryJones, and @christophherr for your reviews and comments on this stuff. 

Ideas for future improvements:

- Add JavaScript linting with ESLint or similar.
- Integrate with Travis or similar to free us from running phpcs manually.
