### PR TITLE
Beta logo size

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -81,6 +81,14 @@ function genesis_sample_enqueue_scripts_styles() {
 		genesis_sample_responsive_menu_settings()
 	);
 
+	wp_enqueue_script(
+		'genesis-sample',
+		get_stylesheet_directory_uri() . '/js/genesis-sample.js',
+		array( 'jquery' ),
+		CHILD_THEME_VERSION,
+		true
+	);
+
 }
 
 /**

--- a/functions.php
+++ b/functions.php
@@ -161,18 +161,6 @@ add_theme_support(
 	)
 );
 
-// Adds support for editor color palette.
-add_theme_support( 'editor-color-palette',
-	'#f5f5f5',
-	'#999999',
-	'#333333',
-	get_theme_mod( 'genesis_sample_link_color', genesis_sample_customizer_get_default_link_color() ),
-	get_theme_mod( 'genesis_sample_accent_color', genesis_sample_customizer_get_default_accent_color() )
-);
-
-// Adds support for wide images, galleries, and videos.
-add_theme_support( 'align-wide' );
-
 // Adds support for after entry widget.
 add_theme_support( 'genesis-after-entry-widget-area' );
 

--- a/functions.php
+++ b/functions.php
@@ -138,8 +138,8 @@ add_theme_support(
 // Adds custom logo in Customizer > Site Identity.
 add_theme_support(
 	'custom-logo', array(
-		'height'      => 60,
-		'width'       => 200,
+		'height'      => 120,
+		'width'       => 700,
 		'flex-height' => true,
 		'flex-width'  => true,
 	)

--- a/js/genesis-sample.js
+++ b/js/genesis-sample.js
@@ -12,7 +12,7 @@ var genesisSample = ( function( $ ) {
 	/**
 	 * Adjust site inner margin top to compensate for sticky header height.
 	 *
-	 * @since 2.4.0
+	 * @since 2.6.0
 	 */
 	var moveContentBelowFixedHeader = function() {
 		var siteInnerMarginTop = 0;
@@ -29,7 +29,7 @@ var genesisSample = ( function( $ ) {
 	 *
 	 * Internal functions to execute on document ready can be called here.
 	 *
-	 * @since 2.4.0
+	 * @since 2.6.0
 	 */
 	init = function() {
 		// Run on first load.

--- a/js/genesis-sample.js
+++ b/js/genesis-sample.js
@@ -1,0 +1,61 @@
+/**
+ * Genesis Sample entry point.
+ *
+ * @package GenesisSample\JS
+ * @author  StudioPress
+ * @license GPL-2.0+
+ */
+
+var genesisSample = ( function( $ ) {
+	'use strict';
+
+	/**
+	 * Adjust site inner margin top to compensate for sticky header height.
+	 *
+	 * @since 2.4.0
+	 */
+	var moveContentBelowFixedHeader = function() {
+		var siteInnerMarginTop = 0;
+
+		if( $('.site-header').css('position') === 'fixed' ) {
+			siteInnerMarginTop = $('.site-header').outerHeight();
+		}
+
+		$('.site-inner').css('margin-top', siteInnerMarginTop);
+	},
+
+	/**
+	 * Initialize Genesis Sample.
+	 *
+	 * Internal functions to execute on document ready can be called here.
+	 *
+	 * @since 2.4.0
+	 */
+	init = function() {
+		// Run on first load.
+		moveContentBelowFixedHeader();
+
+		// Run after window resize.
+		$( window ).resize(function() {
+			moveContentBelowFixedHeader();
+		});
+
+		// Run after the Customizer updates.
+		// 1.5s delay is to allow logo area reflow.
+		if (typeof wp.customize != "undefined") {
+			wp.customize.bind( 'change', function ( setting ) {
+				setTimeout(function() {
+					moveContentBelowFixedHeader();
+				  }, 1500);
+			});
+		}
+	};
+
+	// Expose the init function only.
+	return {
+		init: init
+	};
+
+})( jQuery );
+
+jQuery( genesisSample.init );

--- a/js/genesis-sample.js
+++ b/js/genesis-sample.js
@@ -27,7 +27,7 @@ var genesisSample = ( function( $ ) {
 	/**
 	 * Initialize Genesis Sample.
 	 *
-	 * Internal functions to execute on document ready can be called here.
+	 * Internal functions to execute on document load can be called here.
 	 *
 	 * @since 2.6.0
 	 */
@@ -58,4 +58,4 @@ var genesisSample = ( function( $ ) {
 
 })( jQuery );
 
-jQuery( genesisSample.init );
+jQuery( window ).on( 'load', genesisSample.init );

--- a/lib/customize.php
+++ b/lib/customize.php
@@ -62,13 +62,18 @@ function genesis_sample_customizer_register( $wp_customize ) {
 		)
 	);
 
-	$wp_customize->add_setting( 'genesis_sample_logo_width' );
+	$wp_customize->add_setting(
+		'genesis_sample_logo_width',
+		array(
+			'default'           => 350,
+			'sanitize_callback' => 'absint',
+		)
+	);
 
 	// Add a control for the logo size.
 	$wp_customize->add_control(
 		'genesis_sample_logo_width',
 		array(
-			'default'     => 350,
 			'label'       => __( 'Logo Width', 'genesis-sample' ),
 			'description' => __( 'The maximum width of the logo in pixels.', 'genesis-sample' ),
 			'priority'    => 9,

--- a/lib/customize.php
+++ b/lib/customize.php
@@ -62,4 +62,24 @@ function genesis_sample_customizer_register( $wp_customize ) {
 		)
 	);
 
+	$wp_customize->add_setting( 'genesis_sample_logo_width' );
+
+	// Add a control for the logo size.
+	$wp_customize->add_control(
+		'genesis_sample_logo_width',
+		array(
+			'default'     => 350,
+			'label'       => __( 'Logo Width', 'genesis-sample' ),
+			'description' => __( 'The maximum width of the logo in pixels.', 'genesis-sample' ),
+			'priority'    => 9,
+			'section'     => 'title_tagline',
+			'settings'    => 'genesis_sample_logo_width',
+			'type'        => 'number',
+			'input_attrs' => array(
+				'min' => 100,
+			),
+
+		)
+	);
+
 }

--- a/lib/output.php
+++ b/lib/output.php
@@ -109,6 +109,7 @@ function genesis_sample_css() {
 
 		.wp-custom-logo .title-area {
 			margin: 0 auto;
+			text-align: center;
 		}
 
 		@media only screen and (min-width: 960px) {

--- a/lib/output.php
+++ b/lib/output.php
@@ -31,6 +31,7 @@ function genesis_sample_css() {
 		$logo_width            = absint( $logo[1] );
 		$logo_ratio            = $logo_width / $logo_height;
 		$logo_effective_height = min( $logo_width, $logo_max_width ) / $logo_ratio;
+		$logo_padding          = $logo_effective_height > 100 ? ()
 	}
 
 	$css = '';

--- a/lib/output.php
+++ b/lib/output.php
@@ -31,7 +31,7 @@ function genesis_sample_css() {
 		$logo_width            = absint( $logo[1] );
 		$logo_ratio            = $logo_width / $logo_height;
 		$logo_effective_height = min( $logo_width, $logo_max_width ) / $logo_ratio;
-		$logo_padding          = $logo_effective_height > 100 ? ()
+		$logo_padding          = max( 0, ( 60 - $logo_effective_height ) / 2 );
 	}
 
 	$css = '';
@@ -124,6 +124,15 @@ function genesis_sample_css() {
 		}
 		'
 	: '';
+
+	$css .= ( has_custom_logo() && $logo_padding ) ? sprintf(
+		'
+		.wp-custom-logo .title-area {
+			padding-top: %1$spx;
+			padding-bottom: %1$spx;
+		}
+		', $logo_padding + 5
+	) : '';
 
 	if ( $css ) {
 		wp_add_inline_style( $handle, $css );

--- a/lib/output.php
+++ b/lib/output.php
@@ -128,8 +128,7 @@ function genesis_sample_css() {
 	$css .= ( has_custom_logo() && $logo_padding ) ? sprintf(
 		'
 		.wp-custom-logo .title-area {
-			padding-top: %1$spx;
-			padding-bottom: %1$spx;
+			padding-top: %spx;
 		}
 		', $logo_padding + 5
 	) : '';

--- a/lib/output.php
+++ b/lib/output.php
@@ -21,8 +21,9 @@ function genesis_sample_css() {
 
 	$handle = defined( 'CHILD_THEME_NAME' ) && CHILD_THEME_NAME ? sanitize_title_with_dashes( CHILD_THEME_NAME ) : 'child-theme';
 
-	$color_link   = get_theme_mod( 'genesis_sample_link_color', genesis_sample_customizer_get_default_link_color() );
-	$color_accent = get_theme_mod( 'genesis_sample_accent_color', genesis_sample_customizer_get_default_accent_color() );
+	$color_link     = get_theme_mod( 'genesis_sample_link_color', genesis_sample_customizer_get_default_link_color() );
+	$color_accent   = get_theme_mod( 'genesis_sample_accent_color', genesis_sample_customizer_get_default_accent_color() );
+	$logo_max_width = get_theme_mod( 'genesis_sample_logo_width', false );
 
 	$css = '';
 
@@ -72,6 +73,41 @@ function genesis_sample_css() {
 		}
 		', $color_accent, genesis_sample_color_contrast( $color_accent )
 	) : '';
+
+	if ( $logo_max_width && has_custom_logo() ) {
+		$css .=
+		"
+		.wp-custom-logo .site-container .title-area {
+			max-width: {$logo_max_width}px;
+		}
+		";
+
+		// Place menu below logo and center logo once it gets big.
+		if ( $logo_max_width >= 600 ) {
+			$css .=
+			'
+			.wp-custom-logo .title-area,
+			.wp-custom-logo .menu-toggle,
+			.wp-custom-logo .nav-primary {
+				float: none;
+			}
+
+			.wp-custom-logo .title-area {
+				margin: 0 auto;
+			}
+
+			@media only screen and (min-width: 960px) {
+				.wp-custom-logo .nav-primary {
+					text-align: center;
+				}
+				.wp-custom-logo .sub-menu {
+					text-align: left;
+				}
+			}
+			';
+
+		}
+	}
 
 	if ( $css ) {
 		wp_add_inline_style( $handle, $css );

--- a/lib/output.php
+++ b/lib/output.php
@@ -21,9 +21,14 @@ function genesis_sample_css() {
 
 	$handle = defined( 'CHILD_THEME_NAME' ) && CHILD_THEME_NAME ? sanitize_title_with_dashes( CHILD_THEME_NAME ) : 'child-theme';
 
-	$color_link     = get_theme_mod( 'genesis_sample_link_color', genesis_sample_customizer_get_default_link_color() );
-	$color_accent   = get_theme_mod( 'genesis_sample_accent_color', genesis_sample_customizer_get_default_accent_color() );
-	$logo_max_width = get_theme_mod( 'genesis_sample_logo_width', false );
+	$color_link            = get_theme_mod( 'genesis_sample_link_color', genesis_sample_customizer_get_default_link_color() );
+	$color_accent          = get_theme_mod( 'genesis_sample_accent_color', genesis_sample_customizer_get_default_accent_color() );
+	$logo                  = wp_get_attachment_image_src( get_theme_mod( 'custom_logo' ), 'full' );
+	$logo_effective_height = min( $logo_width, $logo_max_width ) / $logo_ratio;
+	$logo_height           = absint( $logo[2] );
+	$logo_max_width        = get_theme_mod( 'genesis_sample_logo_width', 350 );
+	$logo_width            = absint( $logo[1] );
+	$logo_ratio            = $logo_width / $logo_height;
 
 	$css = '';
 
@@ -74,40 +79,46 @@ function genesis_sample_css() {
 		', $color_accent, genesis_sample_color_contrast( $color_accent )
 	) : '';
 
-	if ( $logo_max_width && has_custom_logo() ) {
-		$css .=
-		"
+	$css .= ( has_custom_logo() && ( 200 <= $logo_effective_height ) ) ?
+		'
+		.site-header {
+			position: static;
+		}
+		'
+	: '';
+
+	$css .= ( has_custom_logo() && ( 350 !== $logo_max_width ) ) ? sprintf(
+		'
 		.wp-custom-logo .site-container .title-area {
-			max-width: {$logo_max_width}px;
+			max-width: %spx;
 		}
-		";
+		', $logo_max_width
+	) : '';
 
-		// Place menu below logo and center logo once it gets big.
-		if ( $logo_max_width >= 600 ) {
-			$css .=
-			'
-			.wp-custom-logo .title-area,
-			.wp-custom-logo .menu-toggle,
+	// Place menu below logo and center logo once it gets big.
+	$css .= ( has_custom_logo() && ( 600 <= $logo_max_width ) ) ?
+		'
+		.wp-custom-logo .title-area,
+		.wp-custom-logo .menu-toggle,
+		.wp-custom-logo .nav-primary {
+			float: none;
+		}
+
+		.wp-custom-logo .title-area {
+			margin: 0 auto;
+		}
+
+		@media only screen and (min-width: 960px) {
 			.wp-custom-logo .nav-primary {
-				float: none;
+				text-align: center;
 			}
 
-			.wp-custom-logo .title-area {
-				margin: 0 auto;
+			.wp-custom-logo .nav-primary .sub-menu {
+				text-align: left;
 			}
-
-			@media only screen and (min-width: 960px) {
-				.wp-custom-logo .nav-primary {
-					text-align: center;
-				}
-				.wp-custom-logo .sub-menu {
-					text-align: left;
-				}
-			}
-			';
-
 		}
-	}
+		'
+	: '';
 
 	if ( $css ) {
 		wp_add_inline_style( $handle, $css );

--- a/lib/output.php
+++ b/lib/output.php
@@ -21,14 +21,17 @@ function genesis_sample_css() {
 
 	$handle = defined( 'CHILD_THEME_NAME' ) && CHILD_THEME_NAME ? sanitize_title_with_dashes( CHILD_THEME_NAME ) : 'child-theme';
 
-	$color_link            = get_theme_mod( 'genesis_sample_link_color', genesis_sample_customizer_get_default_link_color() );
-	$color_accent          = get_theme_mod( 'genesis_sample_accent_color', genesis_sample_customizer_get_default_accent_color() );
-	$logo                  = wp_get_attachment_image_src( get_theme_mod( 'custom_logo' ), 'full' );
-	$logo_effective_height = min( $logo_width, $logo_max_width ) / $logo_ratio;
-	$logo_height           = absint( $logo[2] );
-	$logo_max_width        = get_theme_mod( 'genesis_sample_logo_width', 350 );
-	$logo_width            = absint( $logo[1] );
-	$logo_ratio            = $logo_width / $logo_height;
+	$color_link   = get_theme_mod( 'genesis_sample_link_color', genesis_sample_customizer_get_default_link_color() );
+	$color_accent = get_theme_mod( 'genesis_sample_accent_color', genesis_sample_customizer_get_default_accent_color() );
+	$logo         = wp_get_attachment_image_src( get_theme_mod( 'custom_logo' ), 'full' );
+
+	if ( $logo ) {
+		$logo_height           = absint( $logo[2] );
+		$logo_max_width        = get_theme_mod( 'genesis_sample_logo_width', 350 );
+		$logo_width            = absint( $logo[1] );
+		$logo_ratio            = $logo_width / $logo_height;
+		$logo_effective_height = min( $logo_width, $logo_max_width ) / $logo_ratio;
+	}
 
 	$css = '';
 

--- a/style.css
+++ b/style.css
@@ -925,7 +925,7 @@ img.alignright,
 }
 
 .wp-custom-logo .title-area {
-	max-width: 100px;
+	max-width: 350px;
 	padding-bottom: 5px;
 	padding-top: 5px;
 }

--- a/style.css
+++ b/style.css
@@ -912,7 +912,7 @@ img.alignright,
 .site-header {
 	background-color: #fff;
 	box-shadow: 0 0 20px rgba(0,0,0,0.05);
-	padding: 15px 30px;
+	padding: 0 30px;
 }
 
 /* Title Area
@@ -920,8 +920,8 @@ img.alignright,
 
 .title-area {
 	float: left;
-	padding-bottom: 10px;
-	padding-top: 10px;
+	padding-bottom: 25px;
+	padding-top: 25px;
 }
 
 .wp-custom-logo .title-area {
@@ -1042,6 +1042,7 @@ img.alignright,
 
 .genesis-responsive-menu {
 	display: none;
+	padding-bottom: 15px;
 	position: relative;
 }
 
@@ -1070,7 +1071,7 @@ img.alignright,
 	float: right;
 	line-height: 20px;
 	margin-top: 10px;
-	padding: 0;
+	padding: 15px 0;
 	position: relative;
 	z-index: 1000;
 }
@@ -1447,6 +1448,7 @@ p.entry-meta {
 
 	.genesis-responsive-menu {
 		display: block;
+		padding-top: 15px;
 	}
 
 	.menu-toggle,

--- a/style.css
+++ b/style.css
@@ -171,7 +171,6 @@ body {
 	margin: 0;
 }
 
-a,
 button,
 input:focus,
 input[type="button"],
@@ -186,6 +185,7 @@ textarea:focus,
 a {
 	color: #0073e5;
 	text-decoration: underline;
+	transition: color 0.2s ease-in-out, background-color 0.2s ease-in-out;
 }
 
 a:focus,
@@ -1589,6 +1589,7 @@ p.entry-meta {
 	.gallery img:focus,
 	.gallery img:hover {
 		border: 1px solid #999;
+		outline: none;
 	}
 
 	/* Column Classes

--- a/style.css
+++ b/style.css
@@ -1070,6 +1070,7 @@ img.alignright,
 .menu-toggle {
 	float: right;
 	line-height: 20px;
+	margin-bottom: 10px;
 	margin-top: 10px;
 	padding: 15px 0;
 	position: relative;

--- a/style.css
+++ b/style.css
@@ -526,6 +526,7 @@ th:first-child {
 .site-container {
 	-webkit-animation: fadein 1s;
 	animation:         fadein 1s;
+	word-wrap: break-word;
 }
 
 @keyframes fadein {
@@ -545,7 +546,6 @@ th:first-child {
 	clear: both;
 	margin: 0 auto;
 	padding: 60px 30px 0;
-	word-wrap: break-word;
 }
 
 
@@ -747,7 +747,6 @@ img.alignright,
 
 .widget {
 	margin-bottom: 40px;
-	word-wrap: break-word;
 }
 
 .widget p:last-child,

--- a/style.css
+++ b/style.css
@@ -1516,7 +1516,7 @@ p.entry-meta {
 		padding: 30px;
 	}
 
-	/* After Entry 
+	/* After Entry
 	--------------------------------------------- */
 
 	.after-entry {
@@ -1528,7 +1528,7 @@ p.entry-meta {
 		padding-right: 30px;
 	}
 
-	/* Gallery 
+	/* Gallery
 	--------------------------------------------- */
 
 	.gallery-columns-1 .gallery-item {
@@ -1589,7 +1589,7 @@ p.entry-meta {
 		border: 1px solid #999;
 	}
 
-	/* Column Classes 
+	/* Column Classes
 	--------------------------------------------- */
 
 	.five-sixths,


### PR DESCRIPTION
First pass at a custom logo that allows people to set the max-width themselves from the Customizer.

Current strategy is to:

- Allow people to upload a logo at any size (flex-height and flex-width, with a suggested size of 700 × 120 for display at 350px wide by default).
- Default to a max-width of 350px, but expose a setting to let people increase or decrease that:
    ![logo-width-setting](https://user-images.githubusercontent.com/647669/37362251-021105be-26f5-11e8-9a45-b6903d64972f.png)
- If the logo width is set to 600px or higher, automatically center the logo and menu at all screen widths:
    ![auto-center](https://user-images.githubusercontent.com/647669/37362334-2ec232fe-26f5-11e8-9256-e31e1dcb6184.png)
- Let the regular menu float to the right of the logo at logo widths smaller than 600px. With lots of menu items it may get ugly at some screen widths, but people can adjust their logo width and number of menu items to find the right balance for them.
- Account for the variable height of the custom logo at different screen widths by setting the site-inner top margin with JavaScript on page load, resize, and Customizer update. This prevents the page content from being obscured by the sticky header when scrolled to the top.

@dreamwhisper I looked at removing padding on the header so the logo is edge-to-edge, but it looked wrong for me with logos that use text (people would have to add padding to the image itself to avoid it touching the screen edge).

Other ideas and feedback welcome. 
