### PR TITLE
Fix wp reference error

### DIFF
--- a/js/genesis-sample.js
+++ b/js/genesis-sample.js
@@ -42,7 +42,7 @@ var genesisSample = ( function( $ ) {
 
 		// Run after the Customizer updates.
 		// 1.5s delay is to allow logo area reflow.
-		if (typeof wp.customize != "undefined") {
+		if (typeof wp != "undefined" && typeof wp.customize != "undefined") {
 			wp.customize.bind( 'change', function ( setting ) {
 				setTimeout(function() {
 					moveContentBelowFixedHeader();


### PR DESCRIPTION
In a clean install, this jQuery produces a reference error for wp not defined. This corrects the error by testing for both wp and wp.customize.